### PR TITLE
feat: add schema validator and update README

### DIFF
--- a/starter-code/README.md
+++ b/starter-code/README.md
@@ -13,6 +13,7 @@ A ready-to-run Python server for connecting a content source to Moveworks Enterp
 | File | Purpose |
 |---|---|
 | `content_gateway.py` | Demo server and integration starting point — run it immediately, then edit to connect your source |
+| `validate.py` | Schema validator — run against any live server to confirm your responses conform to the Content Gateway API |
 | `requirements.txt` | Python dependencies |
 | `.env.example` | Template for the environment variables you'll need to set |
 | `openapi.json` | Full Content Gateway API spec |
@@ -48,7 +49,13 @@ Start the demo server with your key:
 GATEWAY_API_KEY=<your-key> python content_gateway.py
 ```
 
-The server starts on port 5001 and returns built-in sample data (Acme IT Knowledge Portal). Expose it over HTTPS (see [Deployment](#deployment)), configure the connector in Moveworks Setup, and trigger an initial sync to confirm Moveworks can reach it.
+The server starts on port 5001 and returns built-in sample data (Acme IT Knowledge Portal). Validate that all endpoints are responding correctly before connecting Moveworks:
+
+```bash
+GATEWAY_API_KEY=<your-key> python validate.py --rebac
+```
+
+Once all checks pass, expose the server over HTTPS (see [Deployment](#deployment)) and follow the [Connecting Your Gateway to Moveworks](https://docs.moveworks.com/api-reference/content-gateway/moveworks-setup) guide to configure the connector.
 
 ## Step 2 — Connect your source system
 
@@ -75,16 +82,28 @@ export $(cat .env | xargs)
 python content_gateway.py
 ```
 
+Before connecting to Moveworks, validate that your real source is returning the correct schema:
+
+```bash
+# Files only — if using Public to all permission strategy
+python validate.py
+
+# Full validation — if using ReBAC permission strategy
+python validate.py --rebac
+```
+
+See the [Verifying Your Build](https://docs.moveworks.com/api-reference/content-gateway/verifying-your-build) guide for a full explanation of what the validator checks and how to fix common failures.
+
 ## Step 3 — Connect to Moveworks
 
 Once your server is deployed and reachable over HTTPS:
 
-1. In **Moveworks Setup**, go to **Enterprise Search > Content Gateway**
-2. Click **Add Gateway** and enter your gateway's public base URL
-3. Set authentication to **API Key** and paste your `GATEWAY_API_KEY` value
+1. In **Moveworks Setup**, navigate to **Core Platform > Connectors > Built-in Connectors** and select **Content Gateway System**
+2. Enter your gateway's public base URL, set authentication to **API Key**, and paste your `GATEWAY_API_KEY` value
+3. Navigate to **Enterprise Search > Configure Search > Classic Ingestion > Files** and click **Create** to configure the ingestion
 4. Save and trigger an initial sync
-5. Go to **Enterprise Search > Resource Permissions**, select your connector, and set the permission model to **ReBAC**
-6. Go to **User Identity**, add your Content Gateway as an identity source, and trigger a sync
+5. Navigate to **Enterprise Search > Resource Permissions > Permission Rules**, click **Create**, and configure your permission strategy (ReBAC or Public)
+6. If using ReBAC, go to **User Identity**, add your Content Gateway as an identity source, and trigger a sync
 
 ## Deployment
 

--- a/starter-code/validate.py
+++ b/starter-code/validate.py
@@ -1,0 +1,341 @@
+"""
+Moveworks Content Gateway — Schema Validator
+════════════════════════════════════════════
+Validates that a running Content Gateway server returns responses that
+conform to the Moveworks Content Gateway API schema.
+
+Run this against your server at any stage:
+  - Against the demo server before connecting a real source
+  - Against your real source after editing content_gateway.py
+  - Against any deployed instance before connecting Moveworks
+
+Works for any source system — it tests protocol conformance, not content.
+
+USAGE
+─────
+  # Set env vars
+  export GATEWAY_API_KEY=your-key
+  export SERVER_URL=http://localhost:5001   # default if not set
+
+  # Validate files only (use when Strategy Config is Public to all)
+  python validate.py
+
+  # Full validation including users, groups, and permissions (use for ReBAC)
+  python validate.py --rebac
+
+  # Validate against a deployed server
+  SERVER_URL=https://your-gateway.example.com python validate.py --rebac
+"""
+
+import argparse
+import os
+import sys
+
+import requests
+
+# ── Configuration ──────────────────────────────────────────────────────────────
+
+SERVER_URL  = os.environ.get("SERVER_URL", "http://localhost:5001").rstrip("/")
+API_KEY     = os.environ.get("GATEWAY_API_KEY", "")
+
+PASS  = "\033[32m✓\033[0m"
+FAIL  = "\033[31m✗\033[0m"
+WARN  = "\033[33m⚠\033[0m"
+SKIP  = "\033[90m–\033[0m"
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+errors_found = 0
+
+
+def check(label: str, passed: bool, detail: str = "") -> bool:
+    global errors_found
+    symbol = PASS if passed else FAIL
+    suffix = f"  {detail}" if detail else ""
+    print(f"  {symbol} {label}{suffix}")
+    if not passed:
+        errors_found += 1
+    return passed
+
+
+def warn(label: str, detail: str = ""):
+    suffix = f"  {detail}" if detail else ""
+    print(f"  {WARN} {label}{suffix}")
+
+
+def section(title: str):
+    print(f"\n{title}")
+    print("─" * len(title))
+
+
+def get(path: str, key: str = API_KEY) -> tuple[int, dict]:
+    try:
+        r = requests.get(f"{SERVER_URL}{path}", headers={"Authorization": f"Bearer {key}"}, timeout=10)
+        try:
+            return r.status_code, r.json()
+        except Exception:
+            return r.status_code, {}
+    except requests.exceptions.ConnectionError:
+        print(f"\n  {FAIL} Could not connect to {SERVER_URL}")
+        print(f"     Is the server running? Start it with:")
+        print(f"     GATEWAY_API_KEY=<key> python content_gateway.py\n")
+        sys.exit(1)
+
+
+def has_keys(obj: dict, *keys) -> tuple[bool, str]:
+    missing = [k for k in keys if k not in obj]
+    return (True, "") if not missing else (False, f"missing fields: {', '.join(missing)}")
+
+
+# ── Validators ─────────────────────────────────────────────────────────────────
+
+def validate_auth():
+    section("Authentication")
+
+    status, _ = get("/v1/files", key="wrong-key")
+    check("Rejects invalid API key with 401", status == 401, f"got HTTP {status}")
+
+    r = requests.get(f"{SERVER_URL}/v1/files", timeout=10)
+    check("Rejects missing Authorization header with 401", r.status_code == 401, f"got HTTP {r.status_code}")
+
+    status, _ = get("/v1/files")
+    check("Accepts valid API key", status == 200, f"got HTTP {status}")
+
+
+def validate_files() -> list[dict]:
+    section("GET /v1/files")
+
+    status, body = get("/v1/files")
+    if not check("Returns HTTP 200", status == 200, f"got {status}"):
+        return []
+
+    ok, detail = has_keys(body, "value", "@odata.context")
+    check("Response has required envelope fields (value, @odata.context)", ok, detail)
+
+    files = body.get("value", [])
+    check("Returns at least one file", len(files) > 0, f"got {len(files)} files")
+
+    if not files:
+        return []
+
+    print(f"       {len(files)} file(s) returned")
+
+    issues = []
+    for i, f in enumerate(files):
+        label = f.get("name", f"file[{i}]")
+
+        ok, detail = has_keys(f, "id", "name", "external_url", "last_modified_datetime", "content")
+        if not ok:
+            issues.append(f"{label}: {detail}")
+            continue
+
+        content = f.get("content", {})
+        if "mime_type" not in content:
+            issues.append(f"{label}: content missing mime_type")
+        elif content["mime_type"] == "text/html":
+            if "body" not in content:
+                issues.append(f"{label}: text/html content missing body field")
+        else:
+            if "download_path" not in content:
+                issues.append(f"{label}: binary content missing download_path field")
+
+        if f.get("status") not in ("active", "deleted", None):
+            issues.append(f"{label}: status must be 'active' or 'deleted', got '{f.get('status')}'")
+
+    check(
+        "All files have required fields and valid content shape",
+        len(issues) == 0,
+        f"\n" + "\n".join(f"       · {i}" for i in issues) if issues else ""
+    )
+
+    return files
+
+
+def validate_single_file(files: list[dict]):
+    if not files:
+        return
+    file_id = files[0]["id"]
+    section(f"GET /v1/files/{{id}}  (testing id={file_id})")
+
+    status, body = get(f"/v1/files/{file_id}")
+    if not check("Returns HTTP 200", status == 200, f"got {status}"):
+        return
+
+    file = body.get("value", {})
+    ok, detail = has_keys(file, "id", "name", "external_url", "last_modified_datetime", "content")
+    check("File object has required fields", ok, detail)
+    check("Returned file id matches requested id", file.get("id") == file_id,
+          f"requested {file_id}, got {file.get('id')}")
+
+
+def validate_permissions(files: list[dict]):
+    if not files:
+        return
+    file_id = files[0]["id"]
+    section(f"GET /v1/files/{{id}}/permissions  (testing id={file_id})")
+
+    status, body = get(f"/v1/files/{file_id}/permissions")
+
+    if status == 404:
+        warn("Endpoint returned 404 — not implemented",
+             "Required for ReBAC. Implement fetch_permissions_for_file() in Section 2.")
+        return
+
+    if not check("Returns HTTP 200", status == 200, f"got {status}"):
+        return
+
+    value = body.get("value", {})
+    ok, detail = has_keys(value, "permissions")
+    if not check("Response has permissions array", ok, detail):
+        return
+
+    permissions = value.get("permissions", [])
+    check("At least one permission entry returned", len(permissions) > 0, f"got {len(permissions)}")
+
+    issues = []
+    for i, p in enumerate(permissions):
+        ok, detail = has_keys(p, "id", "type", "action")
+        if not ok:
+            issues.append(f"permission[{i}]: {detail}")
+            continue
+        if p.get("type") not in ("USER", "GROUP"):
+            issues.append(f"permission[{i}]: type must be USER or GROUP, got '{p.get('type')}'")
+        if p.get("action") != "VIEW":
+            issues.append(f"permission[{i}]: action must be VIEW, got '{p.get('action')}'")
+
+    check(
+        "All permission entries have valid shape",
+        len(issues) == 0,
+        f"\n" + "\n".join(f"       · {i}" for i in issues) if issues else ""
+    )
+
+
+def validate_users():
+    section("GET /v1/users")
+
+    status, body = get("/v1/users")
+
+    if status == 404:
+        warn("Endpoint returned 404 — not implemented",
+             "Required for ReBAC. Implement fetch_users_from_source() in Section 2.")
+        return
+
+    if not check("Returns HTTP 200", status == 200, f"got {status}"):
+        return
+
+    users = body.get("value", [])
+    check("Returns at least one user", len(users) > 0, f"got {len(users)}")
+    print(f"       {len(users)} user(s) returned")
+
+    issues = []
+    for i, u in enumerate(users):
+        ok, detail = has_keys(u, "id", "primary_email_addr")
+        if not ok:
+            issues.append(f"user[{i}]: {detail}")
+
+    check(
+        "All users have required fields (id, primary_email_addr)",
+        len(issues) == 0,
+        f"\n" + "\n".join(f"       · {i}" for i in issues) if issues else ""
+    )
+
+
+def validate_groups():
+    section("GET /v1/groups")
+
+    status, body = get("/v1/groups")
+
+    if status == 404:
+        warn("Endpoint returned 404 — not implemented",
+             "Required for ReBAC. Implement fetch_groups_from_source() in Section 2.")
+        return
+
+    if not check("Returns HTTP 200", status == 200, f"got {status}"):
+        return
+
+    groups = body.get("value", [])
+    check("Returns at least one group", len(groups) > 0, f"got {len(groups)}")
+    print(f"       {len(groups)} group(s) returned")
+
+    issues = []
+    for i, g in enumerate(groups):
+        ok, detail = has_keys(g, "id")
+        if not ok:
+            issues.append(f"group[{i}]: {detail}")
+
+    check(
+        "All groups have required id field",
+        len(issues) == 0,
+        f"\n" + "\n".join(f"       · {i}" for i in issues) if issues else ""
+    )
+
+    # Spot-check members for the first group
+    if groups:
+        group_id = groups[0]["id"]
+        section(f"GET /v1/groups/{{id}}/members  (testing id={group_id})")
+        status, body = get(f"/v1/groups/{group_id}/members")
+
+        if status == 404:
+            warn("Members endpoint returned 404 — not implemented",
+                 "Required for ReBAC group resolution.")
+            return
+
+        if not check("Returns HTTP 200", status == 200, f"got {status}"):
+            return
+
+        members = body.get("value", [])
+        print(f"       {len(members)} member(s) returned")
+
+        issues = []
+        for i, m in enumerate(members):
+            ok, detail = has_keys(m, "id", "type")
+            if not ok:
+                issues.append(f"member[{i}]: {detail}")
+                continue
+            if m.get("type") not in ("USER", "GROUP"):
+                issues.append(f"member[{i}]: type must be USER or GROUP, got '{m.get('type')}'")
+
+        check(
+            "All members have valid shape",
+            len(issues) == 0,
+            f"\n" + "\n".join(f"       · {i}" for i in issues) if issues else ""
+        )
+
+
+# ── Main ───────────────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate a running Content Gateway server against the Moveworks schema.")
+    parser.add_argument("--rebac", action="store_true",
+                        help="Also validate /v1/users, /v1/groups, and /v1/files/{id}/permissions (required for ReBAC)")
+    args = parser.parse_args()
+
+    if not API_KEY:
+        print(f"\n{FAIL} GATEWAY_API_KEY is not set.")
+        print("  Export it before running: export GATEWAY_API_KEY=your-key\n")
+        sys.exit(1)
+
+    print(f"\nMoveworks Content Gateway — Schema Validator")
+    print(f"{'═' * 44}")
+    print(f"  Server:  {SERVER_URL}")
+    print(f"  Mode:    {'ReBAC (full)' if args.rebac else 'Files only  (add --rebac to test users, groups, permissions)'}")
+
+    validate_auth()
+    files = validate_files()
+    validate_single_file(files)
+
+    if args.rebac:
+        validate_permissions(files)
+        validate_users()
+        validate_groups()
+
+    print(f"\n{'═' * 44}")
+    if errors_found == 0:
+        print(f"  {PASS} All checks passed\n")
+    else:
+        print(f"  {FAIL} {errors_found} check(s) failed — fix the issues above before connecting Moveworks\n")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `validate.py` — a schema validator that confirms a running Content Gateway server conforms to the Moveworks API schema
- Works against any source system (tests protocol conformance, not content)
- Two modes: default (files only, for Public permission strategy) and `--rebac` (full validation for ReBAC)
- Updates `README.md` to reference `validate.py` after both Step 1 (demo) and Step 2 (real source), and fixes Step 3 navigation to match current Moveworks Setup UI

## How to use

**Files only** — use when Strategy Config is set to Public to all members:
```bash
GATEWAY_API_KEY=<key> python validate.py
```

**Full validation** — use when Strategy Config is set to ReBAC:
```bash
GATEWAY_API_KEY=<key> python validate.py --rebac
```

**Against a deployed server:**
```bash
SERVER_URL=https://your-gateway.example.com GATEWAY_API_KEY=<key> python validate.py --rebac
```

## What it checks

- Auth: rejects wrong key (401), rejects missing header (401), accepts valid key (200)
- `GET /v1/files` — envelope shape, required fields, content shape per MIME type
- `GET /v1/files/{id}` — single file shape and id match
- `GET /v1/files/{id}/permissions` — permissions array, USER/GROUP types, VIEW action
- `GET /v1/users` — required fields including `primary_email_addr`
- `GET /v1/groups` — required fields
- `GET /v1/groups/{id}/members` — member shape and valid types

**Live docs:** https://docs.moveworks.com/api-reference/content-gateway/verifying-your-build

## Test plan

- [ ] Run `python validate.py --rebac` against the demo server — all checks should pass
- [ ] Run with a wrong key — auth checks should fail clearly

🤖 Generated with [Claude Code](https://claude.com/claude-code)