### PR TITLE
docs(starter-code): clarify rate-limit, capacity, permissions; add schema validator

### DIFF
--- a/starter-code/.env.example
+++ b/starter-code/.env.example
@@ -20,3 +20,9 @@ SOURCE_API_KEY=
 
 # Optional: override the default port (default: 5001)
 # PORT=5001
+
+# Optional (demo mode only): inject the running operator's real email as a
+# sample user so the demo content surfaces in the AI Assistant when this
+# server is connected to a real Moveworks tenant. Comma-separate for multiple.
+# Each injected user is granted access to kb-001 through kb-007.
+# DEMO_TEST_USER_EMAILS=you@yourcompany.com

--- a/starter-code/README.md
+++ b/starter-code/README.md
@@ -1,4 +1,4 @@
-# Moveworks Content Gateway — Starter Code
+# Moveworks Content Gateway: Starter Code
 
 A ready-to-run Python server for connecting a content source to Moveworks Enterprise Search via the Content Gateway API.
 
@@ -6,35 +6,36 @@ A ready-to-run Python server for connecting a content source to Moveworks Enterp
 
 - Python 3.10+
 - pip
-- A publicly reachable HTTPS URL for your server (required for Moveworks to poll it — see [Deployment](#deployment))
+- A publicly reachable HTTPS URL for your server (required for Moveworks to poll it. See [Deployment](#deployment))
 
 ## What's included
 
 | File | Purpose |
 |---|---|
-| `content_gateway.py` | Demo server and integration starting point — run it immediately, then edit to connect your source |
-| `validate.py` | Schema validator — run against any live server to confirm your responses conform to the Content Gateway API |
+| `content_gateway.py` | Demo server and integration starting point. Run it immediately, then edit to connect your source |
+| `validate.py` | Schema validator. Run against any live server to confirm your responses conform to the Content Gateway API |
 | `requirements.txt` | Python dependencies |
 | `.env.example` | Template for the environment variables you'll need to set |
 | `openapi.json` | Full Content Gateway API spec |
 
 ## What's handled vs. what you implement
 
-The server handles the full Content Gateway protocol — you never write that. What you own is the **source layer**.
+The server handles the full Content Gateway protocol. You never write that. What you own is the **source layer**.
 
 | Layer | What it covers | Who writes it |
 |---|---|---|
-| **Protocol** | OData pagination, Bearer auth, error shapes, rate-limit headers | Done — leave it alone |
+| **Protocol** | OData pagination, Bearer auth, error shapes | Done: leave it alone |
+| **Rate-limit headers** | The hook is in place, but values are commented out by default | Uncomment and wire up to your real rate-limit budget when you go to production |
 | **Source** | Calling your API, field mapping, auth to your system | You |
 
 Two patterns that are inherently system-specific and can't be pre-built for you:
 
-- **Multi-source enumeration** — most systems (SharePoint, Confluence, Google Drive) spread content across sites, spaces, or drives. You enumerate those containers and flatten into one stream inside `fetch_files_from_source`.
-- **Permission inheritance** — many systems store ACLs on folders or spaces, not individual documents. You walk the container hierarchy to resolve effective access inside `fetch_permissions_for_file`.
+- **Multi-source enumeration**: most systems (SharePoint, Confluence, Google Drive) spread content across sites, spaces, or drives. You enumerate those containers and flatten into one stream inside `fetch_files_from_source`.
+- **Permission inheritance**: many systems store ACLs on folders or spaces, not individual documents. You walk the container hierarchy to resolve effective access inside `fetch_permissions_for_file`.
 
 Each source function has a docstring that explains which of these applies and what to do about it.
 
-## Step 1 — Verify connectivity with the demo server
+## Step 1: Verify connectivity with the demo server
 
 Install dependencies and generate an API key:
 
@@ -57,19 +58,19 @@ GATEWAY_API_KEY=<your-key> python validate.py --rebac
 
 Once all checks pass, expose the server over HTTPS (see [Deployment](#deployment)) and follow the [Connecting Your Gateway to Moveworks](https://docs.moveworks.com/api-reference/content-gateway/moveworks-setup) guide to configure the connector.
 
-## Step 2 — Connect your source system
+## Step 2: Connect your source system
 
 Edit `content_gateway.py` directly. The file has three labeled sections:
 
-**Section 1 — Configuration**
+**Section 1: Configuration**
 
-Set `SOURCE_API_BASE_URL` to your API's base URL. Then uncomment the `_source_headers()` block that matches your auth method — Bearer token, API key header, OAuth2 client credentials, or no auth. One change there applies everywhere.
+Set `SOURCE_API_BASE_URL` to your API's base URL. Then uncomment the `_source_headers()` block that matches your auth method (Bearer token, API key header, OAuth2 client credentials, or no auth). One change there applies everywhere.
 
-**Section 2 — Source functions**
+**Section 2: Source functions**
 
-Implement the `fetch_*` functions. These call your source API and return raw data. Read the docstring on each function before implementing it — they explain what to return, what pagination patterns to handle, and whether your system is likely to require multi-source enumeration or permission inheritance.
+Implement the `fetch_*` functions. These call your source API and return raw data. Read the docstring on each function before implementing it. They explain what to return, what pagination patterns to handle, and whether your system is likely to require multi-source enumeration or permission inheritance.
 
-**Section 3 — Mapper functions**
+**Section 3: Mapper functions**
 
 Update the field names in `map_item_to_node` (and `map_item_to_user`, `map_item_to_group` if you sync identity) to match your API's response shape. Search for `# TODO` comments.
 
@@ -85,16 +86,31 @@ python content_gateway.py
 Before connecting to Moveworks, validate that your real source is returning the correct schema:
 
 ```bash
-# Files only — if using Public to all permission strategy
+# Files only - if using Public to all permission strategy
 python validate.py
 
-# Full validation — if using ReBAC permission strategy
+# Full validation - if using ReBAC permission strategy
 python validate.py --rebac
 ```
 
 See the [Verifying Your Build](https://docs.moveworks.com/api-reference/content-gateway/verifying-your-build) guide for a full explanation of what the validator checks and how to fix common failures.
 
-## Step 3 — Connect to Moveworks
+## Capacity planning
+
+Moveworks performs scheduled **full sync runs** against your gateway. Each run walks the complete inventory of files, file metadata, file permissions, groups, group memberships, and users. There isn't an incremental-diff mode that only fetches changes.
+
+The main cost savings between syncs come from the **file binary cache**. If you return an accurate `last_modified_datetime` on every file, Moveworks skips re-downloading binaries whose timestamp hasn't changed since the previous sync. File metadata, permissions, group memberships, and users are re-walked each run, but binary downloads (typically the largest payloads) are skipped for unchanged files.
+
+**Concurrent scheduled syncs are skipped, not stacked.** If your previous sync is still running when the next scheduled run would fire, the next run is skipped until the current one completes. You won't see overlapping load on your backend even if first sync exceeds your scheduled cadence.
+
+If your backend has limited capacity, use rate-limit signals to bound the call rate:
+
+- **Proactive**: return `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers on every response. Moveworks paces its calls to fit your advertised capacity, slowing down before you have to fail anything. Variant header names (`X-Rate-Limit-*`, `RateLimit-*`) are also recognized.
+- **Reactive**: return `429 Too Many Requests` with a `Retry-After` header. Moveworks honors the wait value and retries.
+
+Returning fewer items per response than the requested `$top` (with `@odata.nextLink` for the rest) is also a clean way to bound per-request work. Useful when your backend can't sustain large response payloads.
+
+## Step 3: Connect to Moveworks
 
 Once your server is deployed and reachable over HTTPS:
 
@@ -114,17 +130,29 @@ Moveworks polls your gateway on a schedule, so it must be reachable over HTTPS. 
 | **AWS Lambda** | Wrap with a WSGI adapter (e.g. `mangum`) and deploy with `handler` as the entry point |
 | **Azure App Service** | Push to App Service and set environment variables in Application Settings |
 | **Heroku** | `heroku create && git push heroku main`, then `heroku config:set GATEWAY_API_KEY=...` |
-| **Any container / VM** | Standard Flask app — run behind nginx or any reverse proxy |
+| **Any container / VM** | Standard Flask app. Run behind nginx or any reverse proxy |
 
 For local testing, [ngrok](https://ngrok.com) or [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) can expose your local server over HTTPS temporarily.
+
+### Concurrency note for production
+
+The bare `python content_gateway.py` command runs Flask in single-threaded mode. Fine for local testing, **not fine for production**. Moveworks issues multiple concurrent requests against your gateway during a sync (typically up to 20 at once against the same domain). With single-threaded Flask, those requests serialize: each one waits for the previous to finish.
+
+The consequences for a large deployment:
+
+- **First sync stretches dramatically.** A workload that should take an hour with parallelism takes most of a day in series.
+- **Individual requests are more likely to hit timeouts.** A request queued behind 19 others may exceed Moveworks' per-response deadline before it's even handled.
+- **Your backend never benefits from parallelism it could otherwise use.** If your underlying data store is fine with concurrent reads, single-threaded Flask is leaving capacity on the table.
+
+Whichever production host you use, configure it for **concurrent request handling**. The exact mechanism depends on your platform (WSGI worker processes, container concurrency settings, function-as-a-service concurrency limits), but the principle is the same: your gateway should be able to handle multiple in-flight requests simultaneously.
 
 ## Environment variables
 
 | Variable | Required | Description |
 |---|---|---|
-| `GATEWAY_API_KEY` | Yes | The key Moveworks sends to authenticate to your gateway — you generate this value |
+| `GATEWAY_API_KEY` | Yes | The key Moveworks sends to authenticate to your gateway. You generate this value |
 | `SOURCE_API_BASE_URL` | Yes | Your source system's API base URL |
-| `SOURCE_API_KEY` | Depends | Your source system credential — rename to match your system |
+| `SOURCE_API_KEY` | Depends | Your source system credential. Rename to match your system |
 | `PORT` | No | Override the default port (default: `5001`) |
 
 Copy `.env.example` to `.env` for local development. Never commit `.env` to source control.

--- a/starter-code/README.md
+++ b/starter-code/README.md
@@ -83,6 +83,34 @@ export $(cat .env | xargs)
 python content_gateway.py
 ```
 
+## Testing the demo end-to-end with a real Moveworks tenant
+
+The demo's sample users have hardcoded emails (`sarah.chen@acmecorp.internal`, etc.) that won't match any real Moveworks user identity. If you connect this server to your Moveworks tenant as-is, content will ingest successfully but won't surface in search for any real user because Moveworks can't resolve any of the demo identities.
+
+To test end-to-end, set `DEMO_TEST_USER_EMAILS` to your real work email before starting the server:
+
+```bash
+DEMO_TEST_USER_EMAILS=you@yourcompany.com \
+GATEWAY_API_KEY=<your-key> \
+python content_gateway.py
+```
+
+You'll be injected as a sample user, added to `group-it-staff`, and through nested group membership in `group-all-employees` you'll have access to `kb-001` through `kb-007`. You will NOT have access to `kb-008` (HR), `kb-009`, or `kb-010` (Executives), so you can verify permission enforcement is working: those documents should be hidden from your search results in the AI Assistant even though they're ingested.
+
+For multiple test users (e.g., for a small QA group), comma-separate the emails.
+
+### End-to-end test sequence
+
+1. Set `DEMO_TEST_USER_EMAILS` and start the server (above).
+2. Expose it over HTTPS (see [Deployment](#deployment) — `ngrok` works for testing).
+3. In **Moveworks Setup**, create the Content Gateway connector pointing at your HTTPS URL.
+4. Trigger an initial sync. Wait for completion under **Enterprise Search > Indexed Content > Files** (typically under 30 minutes for the 10-file demo set).
+5. Open Moveworks AI Assistant as your real user.
+6. Search for content from the demo (try "VPN setup" for `kb-001`, "incident response" for `kb-004`).
+7. Verify HR-restricted content is hidden — search for "compensation" or "salary"; `kb-008` should not appear.
+
+## Validating the schema
+
 Before connecting to Moveworks, validate that your real source is returning the correct schema:
 
 ```bash

--- a/starter-code/content_gateway.py
+++ b/starter-code/content_gateway.py
@@ -1,15 +1,15 @@
 """
-Moveworks Content Gateway — Starter Server
+Moveworks Content Gateway: Starter Server
 ══════════════════════════════════════════════════════════════════
 This file is both a working demo and your integration starting point.
 
-STEP 1 — RUN IT NOW
+STEP 1: RUN IT NOW
   python content_gateway.py
   The built-in sample data (Acme IT Knowledge Portal) demonstrates every
   supported content type, permission pattern, and group structure. Use it
   to verify your Moveworks connector is wired up before touching any code.
 
-STEP 2 — CONNECT YOUR SOURCE
+STEP 2: CONNECT YOUR SOURCE
   Edit the three labeled sections in this file:
 
   SECTION 1 · CONFIGURATION
@@ -25,11 +25,20 @@ STEP 2 — CONNECT YOUR SOURCE
     Update the field names in map_item_to_node (and map_item_to_user,
     map_item_to_group if you sync identity) to match your API's response shape.
 
-  Everything else — OData pagination, Bearer auth, error shapes, rate-limit
-  headers — is complete and does not need changes.
+  OData pagination, Bearer auth, and error shapes are complete and do not need
+  changes. The rate-limit header hook (`add_rate_limit_headers`) is in place
+  but the values are commented out by default. Wire them up to your real
+  rate-limit budget when you go to production.
 
-Full API spec:  https://help.moveworks.com/api-reference/content-gateway/content-gateway
-Deploy guide:   https://help.moveworks.com/api-reference/content-gateway/starter-code
+Full API spec:  https://docs.moveworks.com/api-reference/content-gateway/content-gateway
+Deploy guide:   https://docs.moveworks.com/api-reference/content-gateway/starter-code
+
+KEY FIELD TO GET RIGHT
+  `last_modified_datetime` on each file (returned by map_item_to_node) is the
+  cache fingerprint Moveworks uses to skip re-downloading unchanged file
+  binaries on subsequent syncs. An accurate, monotonically-updated value is the
+  primary way to keep ongoing ingestion load low. See the map_item_to_node
+  docstring for detail.
 
 Deployment:
   - Local dev:       python content_gateway.py  (port 5001 by default)
@@ -54,7 +63,7 @@ groups_bp = Blueprint("groups", __name__)
 # ============================================================
 # SECTION 1: CONFIGURATION
 # ============================================================
-# All secrets are read from environment variables — never hardcode them here.
+# All secrets are read from environment variables. Never hardcode them here.
 #
 # How to set these depends on your deployment platform:
 #   AWS Lambda:      Secrets Manager or Lambda Environment Variables
@@ -78,21 +87,21 @@ DEFAULT_PAGE_SIZE = 50
 # connecting a real source system.
 DEMO_MODE = not bool(SOURCE_API_BASE_URL)
 
-# ── Auth — uncomment the block that matches your source system ────────────────
+# ── Auth: uncomment the block that matches your source system ────────────────
 # _source_headers() is called by every fetch function. One change here
-# applies everywhere — you never need to touch the fetch functions for auth.
+# applies everywhere. You never need to touch the fetch functions for auth.
 # Only one block should be active at a time.
 
-# BEARER TOKEN (most common — sends Authorization: Bearer <token>)
+# BEARER TOKEN (most common; sends Authorization: Bearer <token>)
 def _source_headers() -> dict:
     return {"Authorization": f"Bearer {SOURCE_API_KEY}"}
 
-# API KEY HEADER — a static key sent in a named header
+# API KEY HEADER: a static key sent in a named header
 # API_KEY_HEADER = "X-API-Key"  # TODO: your header name (e.g. X-API-Key, Api-Key, X-Auth-Token)
 # def _source_headers() -> dict:
 #     return {API_KEY_HEADER: SOURCE_API_KEY}
 
-# OAUTH 2.0 CLIENT CREDENTIALS — exchanges client ID + secret for a short-lived token
+# OAUTH 2.0 CLIENT CREDENTIALS: exchanges client ID + secret for a short-lived token
 # SOURCE_CLIENT_ID     = os.environ.get("SOURCE_CLIENT_ID", "")
 # SOURCE_CLIENT_SECRET = os.environ.get("SOURCE_CLIENT_SECRET", "")
 # TOKEN_URL            = "https://your-system.example.com/oauth/token"  # TODO: your token endpoint
@@ -113,7 +122,7 @@ def _source_headers() -> dict:
 #     _token_cache["expires_at"] = now + data.get("expires_in", 3600)
 #     return {"Authorization": f"Bearer {_token_cache['token']}"}
 
-# NO AUTH — open API, no credentials required
+# NO AUTH: open API, no credentials required
 # def _source_headers() -> dict:
 #     return {}
 
@@ -122,14 +131,13 @@ def _source_headers() -> dict:
 # SECTION 2: SOURCE FUNCTIONS
 # ============================================================
 # Implement the fetch_* functions below to call your source API.
-# These are the only functions you need to write — everything else
-# is handled by the gateway server in Section 4.
-#
+# These are the only functions you need to write. Everything else
+# is handled by the gateway server in Section 4: #
 # Each function has a docstring explaining what to return and what
 # patterns to watch for. When SOURCE_API_BASE_URL is not set, these
 # functions return sample data so you can run the server immediately.
 
-# --- Sample data (used in demo mode only — safe to delete once you connect a real source) ---
+# --- Sample data (used in demo mode only. Safe to delete once you connect a real source) ---
 # Theme: Acme Corp IT Knowledge Portal
 # John (john.m@acmecorp.internal) is in group-it-staff and group-all-employees (via nesting).
 # He does NOT have access to kb-008 (hr), kb-009 (executives), or kb-010 (executives).
@@ -236,7 +244,7 @@ _SAMPLE_FILES = [
     },
     {
         "id": "kb-010",
-        "title": "Board Meeting Deck — April 2026",
+        "title": "Board Meeting Deck. April 2026",
         "url": "https://exec.acmecorp.internal/board/april-2026-deck",
         "updated_at": "2026-04-28T08:00:00Z",
         "created_at": "2026-04-25T10:00:00Z",
@@ -284,7 +292,7 @@ _SAMPLE_GROUP_MEMBERS: dict[str, list[dict]] = {
     ],
 }
 
-# Five permission patterns are demonstrated below — covering the most common
+# Five permission patterns are demonstrated below. Covering the most common
 # real-world scenarios a Content Gateway integration will encounter:
 #
 #   PUBLIC (*)        Group id "*" means every user can see the document.
@@ -293,7 +301,7 @@ _SAMPLE_GROUP_MEMBERS: dict[str, list[dict]] = {
 #   ALL_EMPLOYEES     A top-level group that contains nested sub-groups.
 #                     John is in group-it-staff, which is a member of
 #                     group-all-employees, so he inherits access here.
-#                     Moveworks resolves nesting automatically — you only
+#                     Moveworks resolves nesting automatically. You only
 #                     need to return direct members from each group endpoint.
 #
 #   IT_STAFF          Department-scoped grant. John is a direct member, so
@@ -324,16 +332,16 @@ _SAMPLE_PERMISSIONS: dict[str, list[dict]] = {
 def fetch_files_from_source(skip: int, top: int) -> tuple[list[dict], bool]:
     """
     Fetch a page of documents from your source system. This is one of the two
-    functions you will spend the most time on — it is entirely yours to implement.
+    functions you will spend the most time on. It is entirely yours to implement.
 
     Returns:
         (items, has_more)
           items:    List of raw document dicts from your API. The shape only
-                    matters in map_item_to_node() — return whatever your API gives you.
+                    matters in map_item_to_node(). Return whatever your API gives you.
           has_more: True if there are more pages after this one.
 
     MULTI-SOURCE SYSTEMS (SharePoint, Confluence, Google Drive, Zendesk, ...):
-    Most enterprise content systems organize content across multiple containers —
+    Most enterprise content systems organize content across multiple containers -
     SharePoint has sites, Confluence has spaces, Google Drive has shared drives,
     Zendesk has brands. The Content Gateway expects a single flat stream of
     documents. If that describes your system, enumerate all containers here and
@@ -402,7 +410,7 @@ def fetch_file_bytes_from_source(file_id: str) -> Optional[tuple[bytes, str]]:
     Notes:
       - Only needed for non-HTML content (PDF, DOCX, PPTX, TXT).
       - For HTML content, Moveworks reads the `body` field from
-        fetch_file_from_source() instead — no download is needed.
+        fetch_file_from_source() instead. No download is needed.
 
     TODO: Replace the DEMO_MODE block below with a call to your actual download endpoint.
     """
@@ -431,33 +439,47 @@ def fetch_permissions_for_file(file_id: str) -> list[dict]:
     Return who can view a specific file. This is entirely yours to implement.
 
     Returns a list of permission objects:
-      {"type": "USER" | "GROUP", "id": "<id>", "action": "VIEW" | "UPDATE"}
+      {"type": "USER" | "GROUP", "id": "<id>", "action": "VIEW"}
+
+    Only "VIEW" is currently supported as an action. Other values are rejected
+    by the schema validator.
 
     PERMISSION INHERITANCE (SharePoint, Confluence, Box, Google Drive, ...):
     Many systems do not store permissions on individual documents. Instead, a
     document inherits its access rules from the folder, space, or site that
-    contains it. You have to walk that hierarchy yourself and return the resolved
-    effective permissions. This commonly requires 2-4 API calls per document:
+    contains it. You resolve the effective permissions and return them as a
+    flat list.
+
+    PERFORMANCE (IMPORTANT FOR LARGE CORPORA):
+    This function is called once per file per sync. Walking the inheritance
+    hierarchy with live API calls (2-4 calls per document) multiplies your
+    first-sync load by the same factor. For a 10,000-file corpus that's
+    20,000-40,000 extra calls to your source system on every sync.
+
+    Strongly prefer bulk pre-fetching when your source supports it:
+
+        _PERMISSION_CACHE: dict[str, list[dict]] = {}
+
+        def _ensure_permissions_loaded():
+            if _PERMISSION_CACHE:
+                return
+            # One bulk call (or a small handful) to your source instead of one per file
+            for acl in requests.get(f"{BASE}/all-acls").json():
+                _PERMISSION_CACHE[acl["doc_id"]] = _map_acl_entries(acl["entries"])
 
         def fetch_permissions_for_file(file_id: str) -> list[dict]:
-            # 1. Get the document to find its parent container
-            doc = requests.get(f"{BASE}/documents/{file_id}").json()
-            parent_id = doc.get("parent_id")
+            _ensure_permissions_loaded()
+            return _PERMISSION_CACHE.get(file_id, [{"type": "GROUP", "id": "*", "action": "VIEW"}])
 
-            # 2. Check if the document has its own ACL
-            acl = requests.get(f"{BASE}/documents/{file_id}/acl").json()
-            if not acl.get("inherited"):
-                return _map_acl_entries(acl["entries"])
-
-            # 3. Fall back to the parent folder/space/site ACL
-            parent_acl = requests.get(f"{BASE}/folders/{parent_id}/acl").json()
-            return _map_acl_entries(parent_acl["entries"])
+    Only fall back to per-file live calls when your source has no bulk-fetch
+    capability. And in that case, be deliberate about the per-document call
+    count, because it directly multiplies first-sync duration.
 
     If your content is fully public (no per-document access control), return:
         return [{"type": "GROUP", "id": "*", "action": "VIEW"}]
 
-    The return signature does not change regardless of how many API calls it takes
-    to resolve the permissions — Moveworks always receives the same flat list.
+    The return signature does not change regardless of how you resolve the
+    permissions. Moveworks always receives the same flat list.
 
     TODO: Replace the DEMO_MODE block below with a call to your permission system.
     """
@@ -482,7 +504,7 @@ def fetch_users_from_source(skip: int, top: int) -> tuple[list[dict], bool]:
 
     MULTI-DIRECTORY SYSTEMS (Workday + Azure AD, LDAP + SCIM, ...):
     If your users live in more than one directory, enumerate all directories
-    here and flatten before returning — same pattern as fetch_files_from_source:
+    here and flatten before returning. Same pattern as fetch_files_from_source:
 
         def fetch_users_from_source(skip, top):
             all_users = []
@@ -530,14 +552,27 @@ def fetch_group_members_from_source(
     group_id: str, skip: int, top: int
 ) -> tuple[list[dict], bool]:
     """
-    Fetch direct members (users or sub-groups) of a specific group.
+    Fetch the DIRECT members of a specific group. Users and/or sub-groups.
 
-    Moveworks handles nested group resolution — you only need to return
-    the direct members, not all descendants.
+    Moveworks handles nested group resolution at query time. Return only the
+    direct members of `group_id`, not transitive descendants. If group A
+    contains group B which contains user U, the response for group A is
+    [{"type": "GROUP", "id": "B"}], NOT [{"type": "USER", "id": "U"}].
 
     Returns:
         (members, has_more)
         Each member should be a dict with keys: type ("USER" or "GROUP"), id, name
+
+    PAGINATION (IMPORTANT FOR LARGE GROUPS):
+    Respect the `skip` and `top` parameters and return `has_more=True` when
+    there are more members beyond the current page. The starter handler emits
+    `@odata.nextLink` based on your `has_more` value, and Moveworks follows
+    the chain automatically.
+
+    This matters most for groups with very large membership counts (e.g., an
+    "all employees" group with tens of thousands of members). Returning every
+    member in a single response produces a slow, oversized payload that risks
+    hitting response-time limits. Paginate by honoring `top`.
 
     TODO: Replace the DEMO_MODE block below with a call to your group membership API.
     """
@@ -559,49 +594,75 @@ def fetch_group_members_from_source(
 # Every field marked "required" must always be present and non-null.
 # Optional fields improve search quality but will not break ingestion if omitted.
 
-def map_item_to_node(item: dict) -> dict:
+def map_item_to_node(item: dict, *, include_html_body: bool = False) -> dict:
     """
     Map a raw document from your source API to a Content Gateway Node.
 
     Required fields: id, name, external_url, last_modified_datetime, content.mime_type
-    Optional fields: status, created_datetime, created_by, last_modified_by, custom_attributes
+    Optional fields: size, status, created_datetime, created_by, last_modified_by, custom_attributes
 
     Supported MIME types:
         application/pdf
         application/vnd.openxmlformats-officedocument.wordprocessingml.document  (.docx)
         application/vnd.openxmlformats-officedocument.presentationml.presentation (.pptx)
         text/plain
-        text/html  (inline HTML body — no download endpoint needed)
+        text/html  (inline HTML body. Fetched via /files/{id})
+
+    `last_modified_datetime` is special: Moveworks uses it as a cache fingerprint
+    for the file's BINARY content. On subsequent syncs, files whose timestamp
+    matches the previously cached value skip the /files/{id}/download call
+    entirely. Returning an accurate, monotonically-updated value is the primary
+    way to keep ongoing ingestion load low. Especially for large attachments.
+
+    Note: the cache applies only to binary downloads. HTML files (mime_type ==
+    "text/html") have their body fetched via /files/{id} on every sync, with
+    no equivalent caching. If your corpus is mostly HTML, ongoing load will
+    be roughly the same as first-sync load.
+
+    `include_html_body` controls whether HTML body content is embedded in the
+    response. Default is False (used by the /files list endpoint, where
+    Moveworks does not read body). The /files/{id} endpoint sets this to True
+    so the body comes back inline. Including body unconditionally is wasted
+    payload on every list response.
+
+    `size` (optional but recommended): the file size in bytes. Moveworks
+    currently caps individual file content at 25 MB. Files larger than that
+    are downloaded but then rejected by the indexing pipeline (status
+    FILE_SIZE_LIMIT_EXCEEDED) and never appear in search. Returning an accurate
+    `size` lets future optimizations avoid the wasted download.
 
     TODO: Update each field mapping to match your source API's response shape.
-    The field names on the right (item["title"], item["url"], etc.) are examples —
+    The field names on the right (item["title"], item["url"], etc.) are examples -
     replace them with whatever your API actually returns.
     """
     mime_type = item.get("mime_type", "application/pdf")      # TODO: your MIME type field
 
     content: dict = {
         "mime_type": mime_type,                               # required
-        "size": item.get("file_size"),                        # optional — bytes
+        "size": item.get("file_size"),                        # optional. Bytes; helps with 25MB cap
     }
 
     if mime_type == "text/html":
-        # HTML content is returned inline — no separate download request is needed.
-        content["body"] = item.get("html_body", "")          # TODO: your HTML body field
+        # HTML body is read by Moveworks from the /files/{id} response, not
+        # from the /files list response. Only include body when this mapper
+        # is called for the single-file endpoint.
+        if include_html_body:
+            content["body"] = item.get("html_body", "")      # TODO: your HTML body field
     else:
         content["download_path"] = f"/{item.get('id', '')}/download"  # TODO: your ID field
-        content["sha1_hash"] = item.get("sha1_hash")          # optional — for dedup
+        content["sha1_hash"] = item.get("sha1_hash")          # optional. For dedup
 
     return {
-        "id": str(item["id"]),                               # required — stable unique ID
-        "name": item["title"],                               # required — TODO: your title field
-        "external_url": item["url"],                         # required — TODO: the URL users click
-        "last_modified_datetime": item["updated_at"],        # required — TODO: ISO 8601 timestamp
+        "id": str(item["id"]),                               # required. Stable unique ID
+        "name": item["title"],                               # required. TODO: your title field
+        "external_url": item["url"],                         # required. TODO: the URL users click
+        "last_modified_datetime": item["updated_at"],        # required. TODO: ISO 8601 timestamp
         "status": "deleted" if item.get("archived") else "active",  # TODO: your archive/status logic
         "created_datetime": item.get("created_at"),          # optional
         "created_by": item.get("author_email"),              # optional
         "last_modified_by": item.get("last_editor_email"),   # optional
         "content": content,
-        "custom_attributes": {},                             # optional — add any extra metadata here
+        "custom_attributes": {},                             # optional. Add any extra metadata here
     }
 
 
@@ -667,7 +728,7 @@ def _error_response(http_code: int, code: str, message: str) -> Response:
 @app.before_request
 def validate_auth():
     if not GATEWAY_API_KEY:
-        return  # GATEWAY_API_KEY not set — skipping auth (useful for local dev)
+        return  # GATEWAY_API_KEY not set. Skipping auth (useful for local dev)
 
     authorization = request.headers.get("Authorization", "")
     token = authorization.removeprefix("Bearer ").strip()
@@ -677,12 +738,27 @@ def validate_auth():
 
 @app.after_request
 def add_rate_limit_headers(response: Response) -> Response:
-    # These headers tell Moveworks about your rate limit.
-    # TODO: Replace with real values if you are enforcing a rate limit.
-    # If you add rate limiting (e.g. Flask-Limiter), update these to reflect actual usage.
-    response.headers["X-RateLimit-Limit"] = "600"
-    response.headers["X-RateLimit-Remaining"] = "599"
-    response.headers["X-RateLimit-Reset"] = "60"
+    # Rate-limit headers are how you tell Moveworks how fast it can call your
+    # gateway. Moveworks reads these headers on every response and proactively
+    # slows down its call rate when your remaining capacity drops below ~30% -
+    # no need to wait until you have to return a 429.
+    #
+    # IMPORTANT: emitting static placeholder values is worse than emitting
+    # nothing at all. If you advertise "599 of 600 remaining" on every response,
+    # Moveworks reads "plenty of headroom" and never slows down. Even when
+    # your backend is overloaded. The headers are deliberately commented out
+    # below so a default deployment doesn't accidentally advertise unlimited
+    # capacity.
+    #
+    # When you DO have a real rate limit (Flask-Limiter, AWS API Gateway
+    # throttling, source-system quota, etc.), uncomment the lines below and
+    # update the values per response to reflect your actual current capacity.
+    # Common header-name variants (`X-Rate-Limit-*`, `RateLimit-*` per RFC 9456)
+    # are also recognized.
+
+    # response.headers["X-RateLimit-Limit"]     = str(your_per_minute_limit)
+    # response.headers["X-RateLimit-Remaining"] = str(your_remaining_budget)
+    # response.headers["X-RateLimit-Reset"]     = str(seconds_until_reset)
     return response
 
 
@@ -700,6 +776,8 @@ def list_files() -> Response:
 
     body: dict = {
         "@odata.context": _odata_context_url("Content"),
+        # HTML body is intentionally omitted from list responses. Moveworks
+        # re-fetches it via /files/{id}. See map_item_to_node docstring.
         "value": [map_item_to_node(item) for item in items],
     }
     if has_more:
@@ -730,7 +808,7 @@ def get_file_metadata(file_id: str) -> Response:
 
     body = {
         "@odata.context": _odata_context_url("Content"),
-        "value": map_item_to_node(item),
+        "value": map_item_to_node(item, include_html_body=True),
     }
     return make_response(jsonify(body), 200)
 

--- a/starter-code/content_gateway.py
+++ b/starter-code/content_gateway.py
@@ -87,6 +87,23 @@ DEFAULT_PAGE_SIZE = 50
 # connecting a real source system.
 DEMO_MODE = not bool(SOURCE_API_BASE_URL)
 
+# Demo-only: inject the running user's real email as a sample user, so that
+# when this server is connected to a real Moveworks tenant, the operator can
+# log into the AI Assistant with their normal credentials and see the demo
+# content surface in search results.
+#
+# Without this, the hardcoded sample users (sarah.chen@acmecorp.internal, etc.)
+# won't match any real Moveworks identity, so search returns nothing.
+#
+# Set to one or more comma-separated emails:
+#   DEMO_TEST_USER_EMAILS="you@yourcompany.com,colleague@yourcompany.com"
+#
+# Each injected user is added to group-it-staff, which (via nested membership
+# in group-all-employees) grants access to kb-001 through kb-007. They will
+# still be denied access to kb-008/009/010 (HR and Executives content) so you
+# can verify permission enforcement end-to-end.
+DEMO_TEST_USER_EMAILS = os.environ.get("DEMO_TEST_USER_EMAILS", "")
+
 # ── Auth: uncomment the block that matches your source system ────────────────
 # _source_headers() is called by every fetch function. One change here
 # applies everywhere. You never need to touch the fetch functions for auth.
@@ -327,6 +344,37 @@ _SAMPLE_PERMISSIONS: dict[str, list[dict]] = {
 }
 
 # --- End of sample data ---
+
+
+# Inject DEMO_TEST_USER_EMAILS into the sample identity data so an operator
+# running the demo against a real Moveworks tenant can see the content surface
+# in their AI Assistant.
+def _inject_test_users() -> None:
+    if not (DEMO_MODE and DEMO_TEST_USER_EMAILS):
+        return
+    emails = [e.strip() for e in DEMO_TEST_USER_EMAILS.split(",") if e.strip()]
+    for i, email in enumerate(emails, start=1):
+        user_id = f"user-test-{i}"
+        display_name = email.split("@")[0].replace(".", " ").title()
+        _SAMPLE_USERS.append({
+            "id": user_id,
+            "email": email,
+            "display_name": display_name,
+            "active": True,
+            "updated_at": "2026-01-01T00:00:00Z",
+        })
+        # Add to group-it-staff so they inherit kb-001..kb-007 access via the
+        # group-all-employees nesting. Intentionally NOT added to group-hr or
+        # group-executives so permission enforcement remains observable
+        # (kb-008/009/010 should be hidden from the test user in search).
+        _SAMPLE_GROUP_MEMBERS["group-it-staff"].append({
+            "type": "USER",
+            "id": user_id,
+            "name": display_name,
+        })
+
+
+_inject_test_users()
 
 
 def fetch_files_from_source(skip: int, top: int) -> tuple[list[dict], bool]:

--- a/starter-code/content_gateway.py
+++ b/starter-code/content_gateway.py
@@ -469,13 +469,26 @@ def fetch_permissions_for_file(file_id: str) -> list[dict]:
 
         def fetch_permissions_for_file(file_id: str) -> list[dict]:
             _ensure_permissions_loaded()
-            return _PERMISSION_CACHE.get(file_id, [{"type": "GROUP", "id": "*", "action": "VIEW"}])
+            # Fail closed: an empty list means no one can view this file. Do NOT
+            # default to a public-wildcard entry here -- a partial bulk fetch, a
+            # newly created document, or a race condition would silently grant
+            # public access to a file that may have restricted ACLs.
+            return _PERMISSION_CACHE.get(file_id, [])
 
     Only fall back to per-file live calls when your source has no bulk-fetch
     capability. And in that case, be deliberate about the per-document call
     count, because it directly multiplies first-sync duration.
 
-    If your content is fully public (no per-document access control), return:
+    SECURITY: fail closed on unknown files.
+    If you cannot resolve permissions for a `file_id` (cache miss, source-system
+    404, transient error after retries), return `[]` rather than a public
+    wildcard. An empty list means "no one can view this" -- the file simply will
+    not appear in any user's search results. Returning the wildcard would
+    silently make an unknown file readable by everyone in the org.
+
+    If your content is fully public AND that is an intentional choice for ALL
+    files in your corpus (no per-document access control), then the explicit
+    public wildcard is appropriate:
         return [{"type": "GROUP", "id": "*", "action": "VIEW"}]
 
     The return signature does not change regardless of how you resolve the
@@ -484,12 +497,17 @@ def fetch_permissions_for_file(file_id: str) -> list[dict]:
     TODO: Replace the DEMO_MODE block below with a call to your permission system.
     """
     if DEMO_MODE:
-        return _SAMPLE_PERMISSIONS.get(file_id, [{"type": "GROUP", "id": "*", "action": "VIEW"}])
+        # Fail-closed default: unknown file_id returns no permissions (no one can view).
+        # Do NOT default to a public wildcard here -- see the SECURITY note above.
+        return _SAMPLE_PERMISSIONS.get(file_id, [])
 
     # TODO: call your permission API, e.g.:
     #   response = requests.get(f"{SOURCE_API_BASE_URL}/documents/{file_id}/permissions", ...)
     #   return [{"type": p["entity_type"], "id": p["entity_id"], "action": "VIEW"} for p in response.json()]
-    return [{"type": "GROUP", "id": "*", "action": "VIEW"}]
+    #
+    # Placeholder return below is intentionally fail-closed (no permissions).
+    # Replace with your real permission lookup before connecting to Moveworks.
+    return []
 
 
 def fetch_users_from_source(skip: int, top: int) -> tuple[list[dict], bool]:

--- a/starter-code/openapi.json
+++ b/starter-code/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Content Gateway",
-    "description": "Content Gateway is an extensible approach to integrating custom content systems with Moveworks’ Copilot Search.\n\nThis includes the following features:\n- **Minimal infrastructure**. Just bring your APIs. No job scheduling, indexing, caching, storage, etc.\n- **Simplified traversal**: Moveworks manages traversal logic (pagination / nested structures)\n- **Multiple MIME types**: Supports HTML, PDF, DOCx, PPTx and TXT [mime types](https://developer.mozilla.org/en-US/docs/Web/HTTP/MIME_types/Common_types)\n- **Support many systems**: Build & configure as many content gateway connectors as needed\n",
+    "description": "Content Gateway is an extensible approach to integrating custom content systems with Moveworks’ Copilot Search.\n\nThis includes the following features:\n- **Minimal infrastructure**. Just bring your APIs. No job scheduling, indexing, caching, storage, etc.\n- **Simplified traversal**: Moveworks manages traversal logic (pagination / nested structures)\n- **Multiple MIME types**: Supports HTML, PDF, DOCx, PPTx and TXT [mime types](https://developer.mozilla.org/en-US/docs/Web/HTTP/MIME_types/Common_types)\n- **Support many systems**: Build & configure as many content gateway connectors as needed\n\n## Rate limiting\n\nGateways can throttle Moveworks two ways, used independently or together:\n- **Proactive**: emit `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` on every successful response. Moveworks reads these (and RFC 9456 `RateLimit-*` variants) to pace its call rate before you have to fail anything.\n- **Reactive**: when at capacity, respond `429 Too Many Requests` with a `Retry-After` header. Moveworks honors the wait value and retries.\n\n## File size cap\n\nMoveworks caps individual binary file downloads at **25 MB**. Files larger than this are downloaded and then rejected by indexing with `FILE_SIZE_LIMIT_EXCEEDED`; they will not appear in search results. The error is non-retryable. Filter oversize files out of `/files` at your source rather than letting Moveworks re-download them every sync.\n",
     "version": "1.0.0"
   },
   "servers": [
@@ -65,6 +65,11 @@
         "responses": {
           "200": {
             "description": "Successfully retrieved list of content items with enhanced information.",
+            "headers": {
+              "X-RateLimit-Limit":     { "$ref": "#/components/headers/X-RateLimit-Limit" },
+              "X-RateLimit-Remaining": { "$ref": "#/components/headers/X-RateLimit-Remaining" },
+              "X-RateLimit-Reset":     { "$ref": "#/components/headers/X-RateLimit-Reset" }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -274,7 +279,7 @@
     "/files/{id}/download": {
       "get": {
         "summary": "Download file",
-        "description": "Retrieves and downloads the entire media file based on the specified file ID.\n\nThe response body is the raw binary content of the file. Treat the response body as a byte stream and write it directly to disk or pass it to a file handler.\n\nThe `Content-Type` response header indicates the MIME type of the file (e.g. `application/pdf`, `text/html`). Use this to determine how to handle or display the file.\n\nThe `Checksum-SHA256` response header provides a SHA-256 hash of the file contents. Verify this value against the downloaded bytes to confirm the file was not corrupted in transit.\n",
+        "description": "Retrieves and downloads the entire media file based on the specified file ID.\n\nThe response body is the raw binary content of the file. Treat the response body as a byte stream and write it directly to disk or pass it to a file handler.\n\nThe `Content-Type` response header indicates the MIME type of the file (e.g. `application/pdf`, `text/html`). Use this to determine how to handle or display the file.\n\nThe `Checksum-SHA256` response header provides a SHA-256 hash of the file contents. Verify this value against the downloaded bytes to confirm the file was not corrupted in transit.\n\n**File size cap (25 MB)**: Moveworks caps individual binary downloads at 25 MB. Files larger than this are downloaded by Moveworks, then rejected by the indexing pipeline with status `FILE_SIZE_LIMIT_EXCEEDED` and will not appear in search results. The error is non-retryable. If you knowingly serve oversize files, filter them out of `/files` rather than letting Moveworks re-download them every sync.\n",
         "parameters": [
           {
             "in": "path",
@@ -794,7 +799,7 @@
     "/files/permissions/metadata": {
       "get": {
         "summary": "Get permission model metadata",
-        "description": "Returns the current permission evaluation model. NOTE: `resource_permissions` is the only supported model at this time.",
+        "description": "Returns the current permission evaluation model. Only `resource_permission` is currently consumed by Moveworks ingestion. `hierarchy_permission` is reserved for a future model and should not be returned by gateways today.",
         "responses": {
           "200": {
             "description": "Permissions metadata response",
@@ -882,7 +887,7 @@
     "/files/{id}/permissions": {
       "get": {
         "summary": "Get content permissions",
-        "description": "Returns all user/group permissions on content. If permission model is 'hierarchy_permission', then `permissions_hierarchy` must be provided in the response.",
+        "description": "Returns all user/group permissions on content. Each entry has `type` (USER or GROUP), `id`, and `action: VIEW`. The `permissions_hierarchy` field is reserved for the future `hierarchy_permission` model and is not consumed today.",
         "parameters": [
           {
             "name": "id",
@@ -1024,6 +1029,29 @@
     }
   },
   "components": {
+    "headers": {
+      "X-RateLimit-Limit": {
+        "description": "Maximum number of requests the gateway will accept in the current window. Moveworks reads this header (and RFC 9456 `RateLimit-Limit` variant) to throttle proactively. Optional but strongly recommended in production.",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "X-RateLimit-Remaining": {
+        "description": "Requests remaining in the current window. Moveworks reads this header (and RFC 9456 `RateLimit-Remaining` variant) to pace its call rate.",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "X-RateLimit-Reset": {
+        "description": "Seconds until the rate-limit window resets. Moveworks reads this header (and RFC 9456 `RateLimit-Reset` variant) to know when capacity is restored.",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        }
+      }
+    },
     "schemas": {
       "custom_attributes": {
         "type": "object",
@@ -1183,7 +1211,8 @@
           "size": {
             "type": "integer",
             "format": "int64",
-            "example": 102400
+            "example": 102400,
+            "description": "File size in bytes. Moveworks caps binary downloads at 25 MB (26,214,400 bytes). Files larger than this are downloaded and then rejected by indexing with `FILE_SIZE_LIMIT_EXCEEDED`; they will not appear in search results."
           },
           "sha1_hash": {
             "type": "string",
@@ -1281,7 +1310,11 @@
           },
           "state": {
             "type": "string",
-            "description": "State of the user account. Enum: Active | Inactive"
+            "enum": [
+              "Active",
+              "Inactive"
+            ],
+            "description": "State of the user account."
           },
           "last_modified_datetime": {
             "type": "string",
@@ -1357,7 +1390,11 @@
         "properties": {
           "type": {
             "type": "string",
-            "description": "Entity type. Enum: USER | GROUP"
+            "enum": [
+              "USER",
+              "GROUP"
+            ],
+            "description": "Entity type."
           },
           "id": {
             "type": "string",
@@ -1382,7 +1419,7 @@
               "resource_permission",
               "hierarchy_permission"
             ],
-            "description": "Permission model in use. NOTE: `resource_permissions` is the only supported model at this time."
+            "description": "Permission model in use. Only `resource_permission` is currently consumed by Moveworks ingestion. `hierarchy_permission` is reserved for a future model and should not be returned by gateways today."
           }
         }
       },
@@ -1417,10 +1454,9 @@
                     "action": {
                       "type": "string",
                       "enum": [
-                        "VIEW",
-                        "UPDATE"
+                        "VIEW"
                       ],
-                      "description": "Action permitted on the content."
+                      "description": "Action permitted on the content. Only `VIEW` is consumed by Moveworks ingestion; other values will be rejected by the schema validator."
                     }
                   }
                 }

--- a/starter-code/validate.py
+++ b/starter-code/validate.py
@@ -1,5 +1,5 @@
 """
-Moveworks Content Gateway — Schema Validator
+Moveworks Content Gateway: Schema Validator
 ════════════════════════════════════════════
 Validates that a running Content Gateway server returns responses that
 conform to the Moveworks Content Gateway API schema.
@@ -9,7 +9,7 @@ Run this against your server at any stage:
   - Against your real source after editing content_gateway.py
   - Against any deployed instance before connecting Moveworks
 
-Works for any source system — it tests protocol conformance, not content.
+Works for any source system. It tests protocol conformance, not content.
 
 USAGE
 ─────
@@ -98,8 +98,39 @@ def validate_auth():
     r = requests.get(f"{SERVER_URL}/v1/files", timeout=10)
     check("Rejects missing Authorization header with 401", r.status_code == 401, f"got HTTP {r.status_code}")
 
-    status, _ = get("/v1/files")
-    check("Accepts valid API key", status == 200, f"got HTTP {status}")
+    r = requests.get(f"{SERVER_URL}/v1/files", headers={"Authorization": f"Bearer {API_KEY}"}, timeout=10)
+    check("Accepts valid API key", r.status_code == 200, f"got HTTP {r.status_code}")
+
+    # Rate-limit headers are advisory but recommended. Moveworks reads them to
+    # pace its call rate. Warn if missing rather than fail.
+    rl_headers = {h.lower() for h in r.headers}
+    has_rl = any(h.startswith(("x-ratelimit-", "x-rate-limit-", "ratelimit-")) for h in rl_headers)
+    if has_rl:
+        check("Emits rate-limit headers (X-RateLimit-* or RFC 9456 variants)", True)
+    else:
+        warn("No rate-limit headers found on response",
+             "Moveworks reads X-RateLimit-Limit/Remaining/Reset to throttle proactively. Recommended for production.")
+
+
+def validate_permissions_metadata():
+    section("GET /v1/files/permissions/metadata")
+
+    status, body = get("/v1/files/permissions/metadata")
+
+    if status == 404:
+        warn("Endpoint returned 404. Not implemented",
+             "Required for ReBAC. Should return {\"model\": \"resource_permission\"}.")
+        return
+
+    if not check("Returns HTTP 200", status == 200, f"got {status}"):
+        return
+
+    model = body.get("model")
+    check(
+        "Reports model='resource_permission' (the only supported model)",
+        model == "resource_permission",
+        f"got model='{model}'",
+    )
 
 
 def validate_files() -> list[dict]:
@@ -132,12 +163,11 @@ def validate_files() -> list[dict]:
         content = f.get("content", {})
         if "mime_type" not in content:
             issues.append(f"{label}: content missing mime_type")
-        elif content["mime_type"] == "text/html":
-            if "body" not in content:
-                issues.append(f"{label}: text/html content missing body field")
-        else:
+        elif content["mime_type"] != "text/html":
             if "download_path" not in content:
                 issues.append(f"{label}: binary content missing download_path field")
+        # HTML body is not required in the /files list response. Moveworks
+        # re-fetches it via /files/{id}. The body check happens there instead.
 
         if f.get("status") not in ("active", "deleted", None):
             issues.append(f"{label}: status must be 'active' or 'deleted', got '{f.get('status')}'")
@@ -154,7 +184,11 @@ def validate_files() -> list[dict]:
 def validate_single_file(files: list[dict]):
     if not files:
         return
-    file_id = files[0]["id"]
+    # Prefer testing an HTML file if available, so we can verify the inline-body
+    # contract that Moveworks reads from this endpoint.
+    html_files = [f for f in files if f.get("content", {}).get("mime_type") == "text/html"]
+    test_file = html_files[0] if html_files else files[0]
+    file_id = test_file["id"]
     section(f"GET /v1/files/{{id}}  (testing id={file_id})")
 
     status, body = get(f"/v1/files/{file_id}")
@@ -167,6 +201,15 @@ def validate_single_file(files: list[dict]):
     check("Returned file id matches requested id", file.get("id") == file_id,
           f"requested {file_id}, got {file.get('id')}")
 
+    # HTML body must be inline on /files/{id}. This is where Moveworks reads it.
+    content = file.get("content", {})
+    if content.get("mime_type") == "text/html":
+        check(
+            "text/html content includes inline body on /files/{id}",
+            bool(content.get("body")),
+            "Moveworks reads HTML content from this endpoint's body field, not from /files",
+        )
+
 
 def validate_permissions(files: list[dict]):
     if not files:
@@ -177,7 +220,7 @@ def validate_permissions(files: list[dict]):
     status, body = get(f"/v1/files/{file_id}/permissions")
 
     if status == 404:
-        warn("Endpoint returned 404 — not implemented",
+        warn("Endpoint returned 404. Not implemented",
              "Required for ReBAC. Implement fetch_permissions_for_file() in Section 2.")
         return
 
@@ -193,6 +236,7 @@ def validate_permissions(files: list[dict]):
     check("At least one permission entry returned", len(permissions) > 0, f"got {len(permissions)}")
 
     issues = []
+    wildcard_issues = []
     for i, p in enumerate(permissions):
         ok, detail = has_keys(p, "id", "type", "action")
         if not ok:
@@ -202,12 +246,23 @@ def validate_permissions(files: list[dict]):
             issues.append(f"permission[{i}]: type must be USER or GROUP, got '{p.get('type')}'")
         if p.get("action") != "VIEW":
             issues.append(f"permission[{i}]: action must be VIEW, got '{p.get('action')}'")
+        # Wildcard antipattern: id "*" only works as a public-access wildcard
+        # when paired with type "GROUP". USER+* will not behave as a wildcard.
+        if p.get("id") == "*" and p.get("type") != "GROUP":
+            wildcard_issues.append(
+                f"permission[{i}]: {{type: '{p.get('type')}', id: '*'}} is not a working "
+                "wildcard. Only {type: 'GROUP', id: '*'} grants access to all users"
+            )
 
     check(
         "All permission entries have valid shape",
         len(issues) == 0,
         f"\n" + "\n".join(f"       · {i}" for i in issues) if issues else ""
     )
+
+    if wildcard_issues:
+        for w in wildcard_issues:
+            warn(w)
 
 
 def validate_users():
@@ -216,7 +271,7 @@ def validate_users():
     status, body = get("/v1/users")
 
     if status == 404:
-        warn("Endpoint returned 404 — not implemented",
+        warn("Endpoint returned 404. Not implemented",
              "Required for ReBAC. Implement fetch_users_from_source() in Section 2.")
         return
 
@@ -246,7 +301,7 @@ def validate_groups():
     status, body = get("/v1/groups")
 
     if status == 404:
-        warn("Endpoint returned 404 — not implemented",
+        warn("Endpoint returned 404. Not implemented",
              "Required for ReBAC. Implement fetch_groups_from_source() in Section 2.")
         return
 
@@ -276,7 +331,7 @@ def validate_groups():
         status, body = get(f"/v1/groups/{group_id}/members")
 
         if status == 404:
-            warn("Members endpoint returned 404 — not implemented",
+            warn("Members endpoint returned 404. Not implemented",
                  "Required for ReBAC group resolution.")
             return
 
@@ -315,7 +370,7 @@ def main():
         print("  Export it before running: export GATEWAY_API_KEY=your-key\n")
         sys.exit(1)
 
-    print(f"\nMoveworks Content Gateway — Schema Validator")
+    print(f"\nMoveworks Content Gateway: Schema Validator")
     print(f"{'═' * 44}")
     print(f"  Server:  {SERVER_URL}")
     print(f"  Mode:    {'ReBAC (full)' if args.rebac else 'Files only  (add --rebac to test users, groups, permissions)'}")
@@ -325,6 +380,7 @@ def main():
     validate_single_file(files)
 
     if args.rebac:
+        validate_permissions_metadata()
         validate_permissions(files)
         validate_users()
         validate_groups()
@@ -333,7 +389,7 @@ def main():
     if errors_found == 0:
         print(f"  {PASS} All checks passed\n")
     else:
-        print(f"  {FAIL} {errors_found} check(s) failed — fix the issues above before connecting Moveworks\n")
+        print(f"  {FAIL} {errors_found} check(s) failed. Fix the issues above before connecting Moveworks\n")
         sys.exit(1)
 
 


### PR DESCRIPTION
## Summary

Updates the starter-code to be accurate against Moveworks' actual ingestion behavior, after a multi-round audit against the underlying ingestion code paths. Companion to the docsite PR at moveworks-emu/docs#412.

## `starter-code/content_gateway.py`

- Header docstring: added **KEY FIELD TO GET RIGHT** callout for `last_modified_datetime`; switched URL references from `help.moveworks.com` to `docs.moveworks.com`; corrected the "rate-limit headers are complete" claim to reflect the opt-in pattern.
- `add_rate_limit_headers`: values commented out by default. The prior `599/600` placeholders silently suppressed Moveworks' proactive throttling because they advertised plenty of capacity on every response. Forcing opt-in prevents this footgun.
- `map_item_to_node`: new `include_html_body` parameter. The `/files` list response omits `body` (Moveworks reads HTML body from `/files/{id}`, not from the list). Reduces wasted payload on every list response. Plus a docstring note about the 25 MB file size cap and the binary-only cache behavior.
- `fetch_permissions_for_file`: docstring corrected — only `VIEW` is supported as an action (UPDATE was listed but is rejected by the schema validator and unused by the transform). Suggested pattern updated to recommend bulk pre-fetching over per-document live ACL walks (the previous example multiplied first-sync load by 2-4x).
- `fetch_group_members_from_source`: explicit pagination guidance for large groups; direct-members-only constraint emphasized (Moveworks resolves nesting itself).

## `starter-code/README.md`

- New **Capacity planning** section: explains scheduled full sync runs, the file binary cache via `last_modified_datetime`, and sync overlap protection.
- New **Concurrency note for production**: Flask runs single-threaded by default, Moveworks issues concurrent requests during sync, configure your host for concurrent request handling.
- "What's handled vs what you implement" table: rate-limit headers split out as a separate row to reflect the opt-in pattern.

## `starter-code/validate.py`

Extends the validator with three additional checks (the file itself already exists on `main` from PR #5):

- **(new)** Tests `/v1/files/permissions/metadata` returns `model=resource_permission`
- **(new)** Warns on `{type: USER, id: "*"}` antipattern (only `{type: GROUP, id: "*"}` is interpreted as a wildcard by Moveworks)
- **(new)** Warns when `X-RateLimit-*` headers are missing on the auth check response
- Existing HTML-body check moved from `/v1/files` list to `/v1/files/{id}` (matches the corresponding `map_item_to_node` change)

## Verification

Every claim in this PR is verified against the actual Moveworks ingestion code paths (the Python `/users` driver, the Scrapy-based crawler for files/groups/permissions, the ReBAC transformation layer, the file binary cache mechanism, the OpenFGA wildcard handling, and the 25 MB file size cap enforcement).

## Test plan

Ran the demo server and validator end-to-end against this branch. **All checks pass.**

```
$ pip install -r requirements.txt
$ GATEWAY_API_KEY=<generated> PORT=5002 python3 content_gateway.py
 * Running on http://127.0.0.1:5002

$ SERVER_URL=http://localhost:5002 GATEWAY_API_KEY=<generated> python3 validate.py --rebac

Moveworks Content Gateway: Schema Validator
════════════════════════════════════════════
  Server:  http://localhost:5002
  Mode:    ReBAC (full)

Authentication
──────────────
  ✓ Rejects invalid API key with 401  got HTTP 401
  ✓ Rejects missing Authorization header with 401  got HTTP 401
  ✓ Accepts valid API key  got HTTP 200
  ⚠ No rate-limit headers found on response  Moveworks reads X-RateLimit-Limit/Remaining/Reset to throttle proactively. Recommended for production.

GET /v1/files
─────────────
  ✓ Returns HTTP 200  got 200
  ✓ Response has required envelope fields (value, @odata.context)
  ✓ Returns at least one file  got 10 files
       10 file(s) returned
  ✓ All files have required fields and valid content shape

GET /v1/files/{id}  (testing id=kb-001)
───────────────────────────────────────
  ✓ Returns HTTP 200  got 200
  ✓ File object has required fields
  ✓ Returned file id matches requested id  requested kb-001, got kb-001
  ✓ text/html content includes inline body on /files/{id}  Moveworks reads HTML content from this endpoint's body field, not from /files

GET /v1/files/permissions/metadata
──────────────────────────────────
  ✓ Returns HTTP 200  got 200
  ✓ Reports model='resource_permission' (the only supported model)  got model='resource_permission'

GET /v1/files/{id}/permissions  (testing id=kb-001)
───────────────────────────────────────────────────
  ✓ Returns HTTP 200  got 200
  ✓ Response has permissions array
  ✓ At least one permission entry returned  got 1
  ✓ All permission entries have valid shape

GET /v1/users
─────────────
  ✓ Returns HTTP 200  got 200
  ✓ Returns at least one user  got 5
       5 user(s) returned
  ✓ All users have required fields (id, primary_email_addr)

GET /v1/groups
──────────────
  ✓ Returns HTTP 200  got 200
  ✓ Returns at least one group  got 4
       4 group(s) returned
  ✓ All groups have required id field

GET /v1/groups/{id}/members  (testing id=group-it-staff)
────────────────────────────────────────────────────────
  ✓ Returns HTTP 200  got 200
       2 member(s) returned
  ✓ All members have valid shape

════════════════════════════════════════════
  ✓ All checks passed
```

The one warning (`No rate-limit headers found on response`) is expected and intentional — `add_rate_limit_headers` is commented out by default in this PR so partners don't accidentally advertise misleading static values. Wiring real values up is the documented opt-in step.